### PR TITLE
Fix kanban card reordering logic

### DIFF
--- a/components/kanban/Column.tsx
+++ b/components/kanban/Column.tsx
@@ -2,7 +2,7 @@
 
 import { useSortable, SortableContext } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { GripVertical, Trash2, Plus } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import Card from './Card';

--- a/hooks/useKanbanLogic.ts
+++ b/hooks/useKanbanLogic.ts
@@ -196,7 +196,7 @@ export function useKanbanLogic() {
       sourceColumn.cards.splice(sourceIndex, 1);
       targetColumn.cards.splice(targetIndex, 0, movingCard);
 
-      [...sourceColumn.cards, ...targetColumn.cards].forEach((card, index) => {
+      sourceColumn.cards.forEach((card, index) => {
         card.order = index;
         updateCard.mutate({
           cardId: card.id,
@@ -205,6 +205,18 @@ export function useKanbanLogic() {
           columnId: card.columnId,
         });
       });
+
+      if (sourceColumn.id !== targetColumn.id) {
+        targetColumn.cards.forEach((card, index) => {
+          card.order = index;
+          updateCard.mutate({
+            cardId: card.id,
+            content: card.content,
+            order: card.order,
+            columnId: card.columnId,
+          });
+        });
+      }
     } else {
       const oldIndex = columns.findIndex((c) => c.id === activeId);
       const newIndex = columns.findIndex((c) => c.id === overId);


### PR DESCRIPTION
## Summary
- update kanban card drag end logic to recalc orders per column
- fix lint by removing unused import in Column component

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: @prisma/client Role export errors)*

------
https://chatgpt.com/codex/tasks/task_e_684107a49e548325a5593ad27a1241ee