### PR TITLE
Fix card reset on drag after edit

### DIFF
--- a/app/(protected)/kanban/page.tsx
+++ b/app/(protected)/kanban/page.tsx
@@ -54,10 +54,10 @@ export default function KanbanBoardPage() {
     handleDeleteColumnOptimistic,
     handleDeleteBoardOptimistic,
     handleCreateBoard,
+    handleUpdateCardOptimistic,
     handleDragStart,
     handleDragOver,
     handleDragEnd,
-    updateCard,
     updateColumn,
   } = useKanbanLogic();
 
@@ -166,7 +166,7 @@ export default function KanbanBoardPage() {
                       updateColumn.mutate({ columnId, title, order })
                     }
                     onUpdateCard={(cardId, content, order, columnId) =>
-                      updateCard.mutate({ cardId, content, order, columnId })
+                      handleUpdateCardOptimistic(cardId, content, order, columnId)
                     }
                   />
                 </div>

--- a/hooks/useKanbanLogic.ts
+++ b/hooks/useKanbanLogic.ts
@@ -130,6 +130,28 @@ export function useKanbanLogic() {
     );
   };
 
+  const handleUpdateCardOptimistic = (
+    cardId: string,
+    content: string,
+    order: number,
+    columnId: string,
+  ) => {
+    const column = columns.find((col) => col.id === columnId);
+    if (!column) return;
+    const card = column.cards.find((c) => c.id === cardId);
+    if (!card) return;
+    const previous = card.content;
+    card.content = content;
+    updateCard.mutate(
+      { cardId, content, order, columnId },
+      {
+        onError: () => {
+          card.content = previous;
+        },
+      },
+    );
+  };
+
   const handleCreateBoard = (title: string) => {
     if (!title.trim() || !ownerId) return;
     createBoard.mutate(
@@ -251,6 +273,7 @@ export function useKanbanLogic() {
     handleDeleteColumnOptimistic,
     handleDeleteBoardOptimistic,
     handleAddColumn,
+    handleUpdateCardOptimistic,
     handleCreateBoard,
     handleDragStart,
     handleDragOver,


### PR DESCRIPTION
## Summary
- preserve edited kanban card content when dragging
- use new `handleUpdateCardOptimistic` method in kanban page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68410a7f8d488325a03de0c210cfcfb7