### PR TITLE
Fix Next.js plugin warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import js from '@eslint/js';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import pluginReact from 'eslint-plugin-react';
+import pluginNext from '@next/eslint-plugin-next';
 import { defineConfig } from 'eslint/config';
 export default defineConfig([
   {
@@ -29,4 +30,5 @@ export default defineConfig([
       'react/react-in-jsx-scope': 'off',
     },
   },
+  pluginNext.flatConfig.coreWebVitals,
 ]);


### PR DESCRIPTION
## Summary
- add `@next/eslint-plugin-next` to `eslint.config.js` to prevent build warning

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684281b9954c83258f2d834227aefc08