### PR TITLE
Fix kanban route params

### DIFF
--- a/app/api/kanban/boards/[boardId]/route.ts
+++ b/app/api/kanban/boards/[boardId]/route.ts
@@ -1,8 +1,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> },
+) {
+  const { boardId } = await params;
   const board = await db.kanbanBoard.findUnique({
     where: { id: boardId },
     include: { columns: { include: { cards: true } } },
@@ -10,8 +13,11 @@ export async function GET(req: NextRequest) {
   return NextResponse.json(board);
 }
 
-export async function PUT(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> },
+) {
+  const { boardId } = await params;
   const { title } = await req.json();
   const board = await db.kanbanBoard.update({
     where: { id: boardId },
@@ -20,8 +26,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(board);
 }
 
-export async function DELETE(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> },
+) {
+  const { boardId } = await params;
   await db.kanbanBoard.delete({
     where: { id: boardId },
   });

--- a/app/api/kanban/cards/[cardId]/route.ts
+++ b/app/api/kanban/cards/[cardId]/route.ts
@@ -1,8 +1,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(req: NextRequest) {
-  const cardId = req.nextUrl.pathname.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ cardId: string }> },
+) {
+  const { cardId } = await params;
   const { content, order, columnId } = await req.json();
 
   const card = await db.kanbanCard.update({
@@ -13,8 +16,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(card);
 }
 
-export async function DELETE(req: NextRequest) {
-  const cardId = req.nextUrl.pathname.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ cardId: string }> },
+) {
+  const { cardId } = await params;
 
   await db.kanbanCard.delete({
     where: { id: cardId },

--- a/app/api/kanban/columns/[columnId]/route.ts
+++ b/app/api/kanban/columns/[columnId]/route.ts
@@ -2,8 +2,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(req: NextRequest) {
-  const columnId = req.nextUrl.pathname.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ columnId: string }> },
+) {
+  const { columnId } = await params;
   const { title, order } = await req.json();
 
   const column = await db.kanbanColumn.update({
@@ -14,8 +17,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(column);
 }
 
-export async function DELETE(req: NextRequest) {
-  const columnId = req.nextUrl.pathname.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ columnId: string }> },
+) {
+  const { columnId } = await params;
 
   await db.kanbanColumn.delete({
     where: { id: columnId },


### PR DESCRIPTION
## Summary
- grab `boardId`, `columnId`, and `cardId` from Next.js route params

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68435a44f1908325ae3defd53a9724c5