### PR TITLE
Use params in kanban API routes

### DIFF
--- a/app/api/kanban/boards/[boardId]/route.ts
+++ b/app/api/kanban/boards/[boardId]/route.ts
@@ -1,8 +1,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> }
+) {
+  const { boardId } = await params;
   const board = await db.kanbanBoard.findUnique({
     where: { id: boardId },
     include: { columns: { include: { cards: true } } },
@@ -10,8 +13,11 @@ export async function GET(req: NextRequest) {
   return NextResponse.json(board);
 }
 
-export async function PUT(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> }
+) {
+  const { boardId } = await params;
   const { title } = await req.json();
   const board = await db.kanbanBoard.update({
     where: { id: boardId },
@@ -20,8 +26,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(board);
 }
 
-export async function DELETE(req: NextRequest) {
-  const boardId = req.url.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ boardId: string }> }
+) {
+  const { boardId } = await params;
   await db.kanbanBoard.delete({
     where: { id: boardId },
   });

--- a/app/api/kanban/boards/[boardId]/route.ts
+++ b/app/api/kanban/boards/[boardId]/route.ts
@@ -1,10 +1,7 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(
-  req: NextRequest,
-  { params }: { params: Promise<{ boardId: string }> }
-) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ boardId: string }> }) {
   const { boardId } = await params;
   const board = await db.kanbanBoard.findUnique({
     where: { id: boardId },
@@ -13,10 +10,7 @@ export async function GET(
   return NextResponse.json(board);
 }
 
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: Promise<{ boardId: string }> }
-) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ boardId: string }> }) {
   const { boardId } = await params;
   const { title } = await req.json();
   const board = await db.kanbanBoard.update({
@@ -28,7 +22,7 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: Promise<{ boardId: string }> }
+  { params }: { params: Promise<{ boardId: string }> },
 ) {
   const { boardId } = await params;
   await db.kanbanBoard.delete({

--- a/app/api/kanban/cards/[cardId]/route.ts
+++ b/app/api/kanban/cards/[cardId]/route.ts
@@ -1,10 +1,7 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: Promise<{ cardId: string }> }
-) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ cardId: string }> }) {
   const { cardId } = await params;
   const { content, order, columnId } = await req.json();
 
@@ -18,7 +15,7 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: Promise<{ cardId: string }> }
+  { params }: { params: Promise<{ cardId: string }> },
 ) {
   const { cardId } = await params;
 

--- a/app/api/kanban/cards/[cardId]/route.ts
+++ b/app/api/kanban/cards/[cardId]/route.ts
@@ -1,8 +1,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(req: NextRequest) {
-  const cardId = req.nextUrl.pathname.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ cardId: string }> }
+) {
+  const { cardId } = await params;
   const { content, order, columnId } = await req.json();
 
   const card = await db.kanbanCard.update({
@@ -13,8 +16,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(card);
 }
 
-export async function DELETE(req: NextRequest) {
-  const cardId = req.nextUrl.pathname.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ cardId: string }> }
+) {
+  const { cardId } = await params;
 
   await db.kanbanCard.delete({
     where: { id: cardId },

--- a/app/api/kanban/columns/[columnId]/route.ts
+++ b/app/api/kanban/columns/[columnId]/route.ts
@@ -2,10 +2,7 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: Promise<{ columnId: string }> }
-) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ columnId: string }> }) {
   const { columnId } = await params;
   const { title, order } = await req.json();
 
@@ -19,7 +16,7 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: Promise<{ columnId: string }> }
+  { params }: { params: Promise<{ columnId: string }> },
 ) {
   const { columnId } = await params;
 

--- a/app/api/kanban/columns/[columnId]/route.ts
+++ b/app/api/kanban/columns/[columnId]/route.ts
@@ -2,8 +2,11 @@
 import { db } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function PUT(req: NextRequest) {
-  const columnId = req.nextUrl.pathname.split('/').pop()!;
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ columnId: string }> }
+) {
+  const { columnId } = await params;
   const { title, order } = await req.json();
 
   const column = await db.kanbanColumn.update({
@@ -14,8 +17,11 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json(column);
 }
 
-export async function DELETE(req: NextRequest) {
-  const columnId = req.nextUrl.pathname.split('/').pop()!;
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ columnId: string }> }
+) {
+  const { columnId } = await params;
 
   await db.kanbanColumn.delete({
     where: { id: columnId },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix",
-    "format": "prettier --check .",
-    "format:fix": "prettier --write ."
+    "format": "prettier --write ."
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"


### PR DESCRIPTION
## Summary
- use `params` in kanban board, column and card API route handlers

## Testing
- `npm run lint`
- `npm run build`


