### PR TITLE
Fix lint errors for chat emitter

### DIFF
--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -113,7 +113,7 @@ const resolvers = {
 
 const schema = createSchema({ typeDefs, resolvers });
 
-const yoga = createYoga({
+const { handleRequest } = createYoga({
   schema,
   graphqlEndpoint: '/api/graphql',
   fetchAPI: { Request, Response, Headers },
@@ -124,5 +124,8 @@ const yoga = createYoga({
   },
 });
 
-export const GET = yoga;
-export const POST = yoga;
+async function handler(request: Request) {
+  return handleRequest(request, {});
+}
+
+export { handler as GET, handler as POST };

--- a/lib/chatEmitter.ts
+++ b/lib/chatEmitter.ts
@@ -1,8 +1,16 @@
 import { EventEmitter } from 'events';
 
-// global emitter for chat messages
-export const chatEmitter: EventEmitter = (global as any).chatEmitter || new EventEmitter();
+declare global {
+  // Augment the global object so we can store a single EventEmitter instance
+  // across modules without using `any`.
+  // eslint-disable-next-line no-var
+  var chatEmitter: EventEmitter | undefined;
+}
 
-if (!(global as any).chatEmitter) {
-  (global as any).chatEmitter = chatEmitter;
+// Use the existing emitter if it was previously attached to `globalThis`
+// to ensure a single shared instance.
+export const chatEmitter: EventEmitter = globalThis.chatEmitter ?? new EventEmitter();
+
+if (!globalThis.chatEmitter) {
+  globalThis.chatEmitter = chatEmitter;
 }


### PR DESCRIPTION
## Summary
- fix global event emitter typings to satisfy lint rules

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6843935083c48325b37ecd2c9a323e96