### PR TITLE
Add Chat link to sidebar

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Settings as SettingsIcon,
   Users as UsersIcon,
   KanbanSquare,
+  MessageCircle,
 } from 'lucide-react';
 
 export function Sidebar() {
@@ -29,6 +30,7 @@ export function Sidebar() {
     ? [
         { href: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
         { href: '/kanban', icon: KanbanSquare, label: 'Kanban ' },
+        { href: '/chat', icon: MessageCircle, label: 'Chat' },
         { href: '/profile', icon: UserIcon, label: 'Profile' },
         { href: '/users', icon: UsersIcon, label: 'Users' },
         { href: '/settings', icon: SettingsIcon, label: 'Settings' },


### PR DESCRIPTION
## Summary
- include `MessageCircle` icon
- show new Chat link in Sidebar for authenticated users

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684398cf60208325813f95a699eb2760