### PR TITLE
Fix missing message table and add conversation title

### DIFF
--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -137,6 +137,14 @@ export default function ChatPage() {
     searchResults.find((u: User) => u.id === selected) ??
     null;
 
+  useEffect(() => {
+    if (selectedUser) {
+      document.title = `${selectedUser.firstName} ${selectedUser.lastName} - Chat`;
+    } else {
+      document.title = 'Chat';
+    }
+  }, [selectedUser]);
+
   return (
     <div className="flex h-full bg-white dark:bg-gray-900">
       <aside className="w-64 space-y-2 border-r p-4">
@@ -185,26 +193,27 @@ export default function ChatPage() {
             ))}
       </aside>
       <div className="flex flex-1 flex-col">
-        <div className="border-b p-4 text-sm font-medium">
+        <div className="flex h-12 items-center border-b p-4 text-lg font-semibold">
           {selectedUser ? (
-            <span>
-              Chatting with {selectedUser.firstName} {selectedUser.lastName}
-            </span>
+            <h2>
+              {selectedUser.firstName} {selectedUser.lastName}
+            </h2>
           ) : (
             <span>Select a conversation</span>
           )}
         </div>
-        <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        <div className="flex-1 space-y-2 overflow-y-auto border p-4">
           {messages.map((m: Message) => (
-            <div
-              key={m.id}
-              className={`max-w-[70%] rounded-lg p-2 text-sm ${
-                m.senderId === session?.user?.id
-                  ? 'self-end bg-blue-500 text-white'
-                  : 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
-              }`}
-            >
-              {m.content}
+            <div key={m.id} className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[70%] rounded-lg p-2 text-sm ${
+                  m.senderId === session?.user?.id
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
+                }`}
+              >
+                {m.content}
+              </div>
             </div>
           ))}
         </div>

--- a/prisma/migrations/20250604000000_add_messages/migration.sql
+++ b/prisma/migrations/20250604000000_add_messages/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "deletedForSender" BOOLEAN NOT NULL DEFAULT false,
+    "deletedForRecipient" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Message_senderId_recipientId_idx" ON "Message"("senderId", "recipientId");
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add migration for `Message` table
- show selected recipient in the chat header
- align message bubbles left and right
- outline the chat history box

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68439c9ed7048325b7c8cbcc4300a3be