### PR TITLE
Improve chat layout with bottom scroll

### DIFF
--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -151,7 +151,7 @@ export default function ChatPage() {
   }, [selectedUser]);
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] bg-white dark:bg-gray-900">
+    <div className="flex h-[calc(100vh-3.5rem)] overflow-hidden bg-white dark:bg-gray-900">
       <aside className="flex h-full w-64 flex-col border-r p-4">
         <Input
           placeholder="Search users"
@@ -211,7 +211,7 @@ export default function ChatPage() {
             <span>Select a conversation</span>
           )}
         </div>
-        <div className="flex flex-1 flex-col justify-end space-y-2 overflow-y-auto border p-4">
+        <div className="flex flex-1 flex-col justify-end space-y-2 overflow-y-auto border p-4 pb-6">
           {messages.map((m: Message) => (
             <div key={m.id} className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}>
               <div

--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -151,7 +151,7 @@ export default function ChatPage() {
   }, [selectedUser]);
 
   return (
-    <div className="flex h-[calc(94vh)] overflow-hidden bg-white dark:bg-gray-900">
+    <div className="flex h-[calc(93vh)] overflow-hidden bg-white dark:bg-gray-900">
       <aside className="flex h-full w-64 flex-col border-r p-4">
         <Input
           placeholder="Search users"

--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -151,53 +151,55 @@ export default function ChatPage() {
   }, [selectedUser]);
 
   return (
-    <div className="flex h-full bg-white dark:bg-gray-900">
-      <aside className="w-64 space-y-2 border-r p-4">
+    <div className="flex h-[calc(100vh-3.5rem)] bg-white dark:bg-gray-900">
+      <aside className="flex h-full w-64 flex-col border-r p-4">
         <Input
           placeholder="Search users"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="mb-2"
         />
-        {search
-          ? searchResults.map((u: User) => (
-              <div
-                key={u.id}
-                className={`cursor-pointer rounded-md p-2 hover:bg-gray-100 dark:hover:bg-gray-800 ${
-                  selected === u.id ? 'bg-blue-500 text-white' : ''
-                }`}
-                onClick={() => {
-                  setSelected(u.id);
-                  setSearch('');
-                }}
-              >
-                {u.firstName} {u.lastName}
-              </div>
-            ))
-          : conversations.map((u: User) => (
-              <div
-                key={u.id}
-                className={`flex items-center justify-between rounded-md p-2 hover:bg-gray-100 dark:hover:bg-gray-800 ${
-                  selected === u.id ? 'bg-blue-500 text-white' : ''
-                }`}
-                onClick={() => setSelected(u.id)}
-              >
-                <span>
-                  {u.firstName} {u.lastName}
-                </span>
-                <button
-                  className="ml-2 text-xs text-red-500"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (confirm('Delete this conversation?')) {
-                      handleDelete(u.id);
-                    }
+        <div className="flex-1 space-y-2 overflow-y-auto">
+          {search
+            ? searchResults.map((u: User) => (
+                <div
+                  key={u.id}
+                  className={`cursor-pointer rounded-md p-2 hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                    selected === u.id ? 'bg-blue-500 text-white' : ''
+                  }`}
+                  onClick={() => {
+                    setSelected(u.id);
+                    setSearch('');
                   }}
                 >
-                  X
-                </button>
-              </div>
-            ))}
+                  {u.firstName} {u.lastName}
+                </div>
+              ))
+            : conversations.map((u: User) => (
+                <div
+                  key={u.id}
+                  className={`flex items-center justify-between rounded-md p-2 hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                    selected === u.id ? 'bg-blue-500 text-white' : ''
+                  }`}
+                  onClick={() => setSelected(u.id)}
+                >
+                  <span>
+                    {u.firstName} {u.lastName}
+                  </span>
+                  <button
+                    className="ml-2 text-xs text-red-500"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (confirm('Delete this conversation?')) {
+                        handleDelete(u.id);
+                      }
+                    }}
+                  >
+                    X
+                  </button>
+                </div>
+              ))}
+        </div>
       </aside>
       <div className="flex flex-1 flex-col">
         <div className="flex h-12 items-center border-b p-4 text-lg font-semibold">

--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { gql, useMutation, useQuery } from '@apollo/client';
 import { apolloClient } from '@/lib/apollo';
 import { Input } from '@/components/ui/input';
@@ -74,6 +74,7 @@ export default function ChatPage() {
   const [message, setMessage] = useState('');
   const [search, setSearch] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   const { data: convoData, refetch: refetchConvos } = useQuery(CONVERSATIONS, {
     client: apolloClient,
@@ -112,6 +113,10 @@ export default function ChatPage() {
   useEffect(() => {
     if (!selected) setMessages([]);
   }, [selected]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
+  }, [messages, selected]);
 
   const handleSend = async () => {
     if (!message.trim() || !selected) return;
@@ -184,10 +189,12 @@ export default function ChatPage() {
                   className="ml-2 text-xs text-red-500"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleDelete(u.id);
+                    if (confirm('Delete this conversation?')) {
+                      handleDelete(u.id);
+                    }
                   }}
                 >
-                  delete
+                  X
                 </button>
               </div>
             ))}
@@ -202,7 +209,7 @@ export default function ChatPage() {
             <span>Select a conversation</span>
           )}
         </div>
-        <div className="flex-1 space-y-2 overflow-y-auto border p-4">
+        <div className="flex flex-1 flex-col justify-end space-y-2 overflow-y-auto border p-4">
           {messages.map((m: Message) => (
             <div key={m.id} className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}>
               <div
@@ -216,6 +223,7 @@ export default function ChatPage() {
               </div>
             </div>
           ))}
+          <div ref={messagesEndRef} />
         </div>
         {selected && (
           <div className="flex items-center gap-2 border-t p-4">

--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -151,7 +151,7 @@ export default function ChatPage() {
   }, [selectedUser]);
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] overflow-hidden bg-white dark:bg-gray-900">
+    <div className="flex h-[calc(94vh)] overflow-hidden bg-white dark:bg-gray-900">
       <aside className="flex h-full w-64 flex-col border-r p-4">
         <Input
           placeholder="Search users"
@@ -211,9 +211,12 @@ export default function ChatPage() {
             <span>Select a conversation</span>
           )}
         </div>
-        <div className="flex flex-1 flex-col justify-end space-y-2 overflow-y-auto border p-4 pb-6">
+        <div className="flex flex-1 flex-col justify-end space-y-2 overflow-y-auto border p-4">
           {messages.map((m: Message) => (
-            <div key={m.id} className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}>
+            <div
+              key={m.id}
+              className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}
+            >
               <div
                 className={`max-w-[70%] rounded-lg p-2 text-sm ${
                   m.senderId === session?.user?.id

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,12 +17,12 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="h-full" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <Analytics />
       <body className="flex h-full flex-col" suppressHydrationWarning>
         <Providers>
           <Navbar />
-          <div className="flex flex-1">
+          <div className="flex h-[calc(90vh)] flex-1">
             <Sidebar />
             <main className="mt-5 flex-1 overflow-y-auto">{children}</main>
           </div>


### PR DESCRIPTION
## Summary
- keep chat area fully expanded in Chat page
- confirm before deleting a conversation
- anchor messages to the bottom with auto-scroll

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843a52b71108325849c94c78505dc04