### PR TITLE
Fix chat newline display

### DIFF
--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -236,7 +236,7 @@ export default function ChatPage() {
               className={`flex ${m.senderId === session?.user?.id ? 'justify-end' : 'justify-start'}`}
             >
               <div
-                className={`max-w-[70%] rounded-lg p-2 text-sm ${
+                className={`max-w-[70%] rounded-lg p-2 text-sm whitespace-pre-line ${
                   m.senderId === session?.user?.id
                     ? 'bg-blue-500 text-white'
                     : 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'


### PR DESCRIPTION
## Summary
- show line breaks in messages

## Testing
- `npx prettier -w "app/(protected)/chat/page.tsx"`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843d4fd98588325a2ddd96ba7d541fd