### PR TITLE
Fix card drag animation

### DIFF
--- a/app/(protected)/kanban/page.tsx
+++ b/app/(protected)/kanban/page.tsx
@@ -159,6 +159,7 @@ export default function KanbanBoardPage() {
                   <Column
                     column={{ ...column, cards: column.cards ?? [] }}
                     isColumnDragging={!activeCard && activeId === column.id}
+                    activeId={activeId}
                     onAddCard={handleAddCardOptimistic}
                     onDeleteCard={handleDeleteCardOptimistic}
                     onDeleteColumn={handleDeleteColumnOptimistic}
@@ -178,7 +179,7 @@ export default function KanbanBoardPage() {
         {/* Drag Preview */}
         <DragOverlay>
           {activeCard ? (
-            <Card card={activeCard} />
+            <Card card={activeCard} isCardDragging={true} />
           ) : activeColumn ? (
             <Column
               column={{ ...activeColumn, cards: activeColumn.cards ?? [] }}

--- a/components/kanban/Card.tsx
+++ b/components/kanban/Card.tsx
@@ -9,11 +9,17 @@ import { CardType } from '@/types/kanban';
 
 type CardProps = {
   card: CardType;
+  isCardDragging?: boolean;
   onDelete?: () => void;
   onUpdate?: (content: string) => void;
 };
 
-function CardComponent({ card, onDelete = () => {}, onUpdate = () => {} }: CardProps) {
+function CardComponent({
+  card,
+  isCardDragging = false,
+  onDelete = () => {},
+  onUpdate = () => {},
+}: CardProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: card.id,
   });
@@ -35,7 +41,9 @@ function CardComponent({ card, onDelete = () => {}, onUpdate = () => {} }: CardP
     <div
       ref={setNodeRef}
       style={style}
-      className="mb-2 min-h-[56px] rounded border bg-white p-2 text-sm shadow-sm dark:bg-neutral-800"
+      className={`mb-2 min-h-[56px] rounded border bg-white p-2 text-sm shadow-sm transition-transform duration-200 ease-in-out dark:bg-neutral-800 ${
+        isCardDragging ? 'opacity-50' : ''
+      }`}
     >
       <div className="flex items-center justify-between">
         <span {...attributes} {...listeners} className="text-muted-foreground cursor-grab">

--- a/components/kanban/Column.tsx
+++ b/components/kanban/Column.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 type ColumnProps = {
   column: ColumnType;
   isColumnDragging: boolean;
+  activeId?: string | null;
   onAddCard?: (columnId: string) => void;
   onDeleteCard?: (columnId: string, cardId: string) => void;
   onDeleteColumn?: (columnId: string) => void;
@@ -23,6 +24,7 @@ const Column = React.memo(
   ({
     column,
     isColumnDragging,
+    activeId = null,
     onAddCard = () => {},
     onDeleteCard = () => {},
     onDeleteColumn = () => {},
@@ -99,8 +101,11 @@ const Column = React.memo(
               <Card
                 key={card.id}
                 card={card}
+                isCardDragging={activeId === card.id}
                 onDelete={() => onDeleteCard(column.id, card.id)}
-                onUpdate={(newContent) => onUpdateCard(card.id, newContent, card.order, column.id)}
+                onUpdate={(newContent) =>
+                  onUpdateCard(card.id, newContent, card.order, column.id)
+                }
               />
             ))}
 


### PR DESCRIPTION
## Summary
- improve card animation while dragging so opacity matches columns
- pass the active ID through Column and Page components

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684662493a448325a96eedc7f86f4a58