### PR TITLE
fix: keep chat name column from shifting on mobile

### DIFF
--- a/app/(protected)/chat/page.tsx
+++ b/app/(protected)/chat/page.tsx
@@ -173,7 +173,7 @@ export default function ChatPage() {
 
   return (
     <div className="flex h-[calc(93vh)] overflow-hidden border-2 bg-white pt-5 dark:bg-gray-900">
-      <aside className="flex h-full w-64 flex-col border-r p-4">
+      <aside className="flex h-full w-64 flex-shrink-0 flex-col border-r p-4">
         <Input
           placeholder="Search users"
           value={search}


### PR DESCRIPTION
## Summary
- stop the sidebar from resizing when I pick a chat user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b586fc9c832594176f075390eaef