### PR TITLE
Restore demo login button text

### DIFF
--- a/components/login/LoginPageClient.tsx
+++ b/components/login/LoginPageClient.tsx
@@ -171,7 +171,7 @@ export default function LoginPageClient({ initialError }: LoginPageClientProps) 
                 });
               }}
             >
-              {loading ? `Logging in…` : 'Login'}
+              {loading ? `Logging in…` : `Login as ${demo.name}`}
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary
- show selected demo user's name in the login button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68993568a1f4832591cf4f3cc1b54088